### PR TITLE
Add link to wikipedia.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Rendezvous
 ==========
 
-Implementation of the Rendezvous or Highest Random Weight (HRW) hashing algorithm in the Elixir Programming Language ([elixir-lang.org](http://elixir-lang.org))
+Implementation of the [Rendezvous or Highest Random Weight (HRW) hashing algorithm](https://en.wikipedia.org/wiki/Rendezvous_hashing) in the Elixir Programming Language ([elixir-lang.org](http://elixir-lang.org))
 
 ## Installation
 


### PR DESCRIPTION
When I stumbled upon this project, I did not know about Rendezvous hashing, so I needed to search for it. Having a direct link is much more convenient.
